### PR TITLE
It is an error to call setState unless mounted is true.

### DIFF
--- a/lib/flutter_reorderable_list.dart
+++ b/lib/flutter_reorderable_list.dart
@@ -611,7 +611,9 @@ class _ReorderableItemState extends State<ReorderableItem> {
   }
 
   void update() {
-    setState(() {});
+    if (mounted) {
+      setState(() {});
+    }
   }
 
   @override


### PR DESCRIPTION
https://api.flutter.dev/flutter/widgets/State/mounted.html

Got this error in my App, and checking "mounted" fixed it: 

```
NoSuchMethodError: NoSuchMethodError: The method 'markNeedsBuild' was called on null.
Receiver: null
Tried calling: markNeedsBuild()
  File "framework.dart", line 1253, in State.setState
  File "flutter_reorderable_list.dart", line 604, in _ReorderableItemState.update
  File "flutter_reorderable_list.dart", line 402, in _ReorderableListState.end
  File "<asynchronous suspension>"
  File "unparsed"
```