### PR TITLE
Fix cancel dragging logic

### DIFF
--- a/lib/flutter_reorderable_list.dart
+++ b/lib/flutter_reorderable_list.dart
@@ -227,7 +227,7 @@ class _ReorderableListState extends State<ReorderableList>
       _dragging = null;
       _dragProxy!.hide();
 
-      var current = _items[_dragging];
+      var current = _items[dragging];
       current?.update();
 
       if (widget.onReorderDone != null) {


### PR DESCRIPTION
The code line 230 seems strange to me because at line 227 `_dragging` is always set to null. Maybe this is a mistake? Please close this PR if it is not.