### PR TITLE
Cancel dragging when the original list item is invisible

### DIFF
--- a/lib/flutter_reorderable_list.dart
+++ b/lib/flutter_reorderable_list.dart
@@ -388,7 +388,10 @@ class _ReorderableListState extends State<ReorderableList>
     this._scrollable!.position.removeListener(this._scrolled);
 
     var current = _items[_dragging];
-    if (current == null) return;
+    if (current == null) {
+      _cancel();
+      return;
+    }
 
     final originalOffset = _itemOffset(current);
     final dragProxyOffset = _dragProxy!.offset;


### PR DESCRIPTION
DragProxy gets stuck when ListView contains a lot of items and we drag it from the end to the start and then release